### PR TITLE
Fix for Product modal on single product embeds

### DIFF
--- a/includes/class-customize.php
+++ b/includes/class-customize.php
@@ -224,7 +224,7 @@ class SECP_Customize {
 			'default' => 'checkout',
 			'options' => array(
 				'checkout' => __( 'Checkout', 'shopify-ecommerce-shopping-cart' ),
-				'product'  => __( 'Product', 'shopify-ecommerce-shopping-cart' ),
+				'modal'  => __( 'Product Modal', 'shopify-ecommerce-shopping-cart' ),
 				'cart'     => __( 'Cart', 'shopify-ecommerce-shopping-cart' ),
 			),
 		) );

--- a/includes/class-output.php
+++ b/includes/class-output.php
@@ -175,6 +175,10 @@ class SECP_Output {
 			$args['product_modal'] = 'true';
 		}
 
+		if ( $args['redirect_to'] === 'modal') {
+			$args['product_modal'] = 'true';
+		}
+
 		if ( empty( $args['shop'] ) || empty( $args['product_handle'] ) ) {
 			// No button if there is no product id or shop url.
 			return;


### PR DESCRIPTION
The product modal option for single products was not opening the modal due to the `redirect_to` option being set to an invalid value. 

The option label has also been updated to `Product Modal` to be consistent with the Shopify options.

@CamdenSegal  @jazzsequence 

CC @danielpatricio @d10k @awkinger 