### PR TITLE
Added a config file for affiliates to be used in the iframes in order to be passed to Shopify

### DIFF
--- a/affiliate_config.php
+++ b/affiliate_config.php
@@ -1,0 +1,4 @@
+<?php
+  // set your affiliate code here i.e. awesome-partner
+  define('AFFILIATE_CODE', '');
+?>

--- a/includes/class-modal.php
+++ b/includes/class-modal.php
@@ -31,7 +31,7 @@ class SECP_Modal {
 	 * @return string HTML markup of modal.
 	 */
 	public function get_modal() {
-		$iframe_url = 'https://widgets.shopifyapps.com/embed_admin/embeds/picker';
+		$iframe_url = 'https://widgets.shopifyapps.com/embed_admin/embeds/picker?ref='.AFFILIATE_CODE;
 
 		$site = get_option( 'secp-connected-site', false );
 		if ( $site ) {

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -107,8 +107,9 @@ class SECP_Settings {
 	 * @since  1.0.0
 	 */
 	public function admin_page_display() {
+		$settings_url = "https://widgets.shopifyapps.com/embed_admin/settings?ref=".AFFILIATE_CODE;
 		?>
-		<iframe class="secp-settings-iframe" src="https://widgets.shopifyapps.com/embed_admin/settings"></iframe>
+		<iframe class="secp-settings-iframe" src="<?php echo esc_url( $settings_url ); ?>"></iframe>
 		<?php
 	}
 }

--- a/shopify-ecommerce-shopping-cart.php
+++ b/shopify-ecommerce-shopping-cart.php
@@ -1,4 +1,5 @@
 <?php
+	include_once("affiliate_config.php");
 /**
  * Plugin Name: Shopify eCommerce Plugin - Shopping Cart
  * Plugin URI:  https://www.shopify.com/buy-button


### PR DESCRIPTION
Added a global config file that affiliates can modify to set their affiliate code and get referrals. 

It is left blank on purpose to avoid someone creating a affiliate code with the dummy value and profiting

Review @lreeves @minasmart 

CC @michael-thorpe @danielpatricio  