### PR TITLE
align embed within preview pane

### DIFF
--- a/includes/class-output.php
+++ b/includes/class-output.php
@@ -279,9 +279,11 @@ class SECP_Output {
 		}
 		<?php if ( isset( $_GET['vcenter'] ) ): ?>
 			.secp-embed-product {
-				position: relative;
-				top: 50%;
-				transform: translateY(-50%);
+			  display: block!important;
+			  margin: 0 auto;
+			  position: relative;
+			  top: 50%;
+			  transform: translateY(-50%);
 			}
 		<?php endif; ?>
 		</style>


### PR DESCRIPTION
when we shipped the adapter we changed some styles that the wordpress plugin was relying on to align the embed within the preview pane. This overrides them. 

@harisaurus @tanema @michelleyschen 